### PR TITLE
Net::SCP.upload! / system_user & raise on ~ in deploy_to

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+Gemfile.lock
+*.gem

--- a/README.md
+++ b/README.md
@@ -17,19 +17,23 @@ And then:
 
 ### Setup and usage
 
-- make sure your local `config/secrets.yml` is not git tracked. It **should be on
+- Make sure your local `config/secrets.yml` is not git tracked. It **should be on
   the disk**, but gitignored.
 
-- populate production secrets in local `config/secrets.yml`:
+- Populate production secrets in local `config/secrets.yml`:
 
         production:
           secret_key_base: d6ced...
 
-- add to `Capfile`:
+- Add to `Capfile`:
 
         require 'capistrano/secrets_yml'
+        
+- Within your app/config/deploy/#{environment}.rb files, make sure to specify:
 
-- create `secrets.yml` file on the remote server by executing this task:
+        set :system_user, 'ssh_user' # defaults to root user; This user will SSH into the servers to generate all necessary files
+
+- Create `secrets.yml` file on the remote server by executing this task:
 
         $ bundle exec cap production setup
 

--- a/lib/capistrano/secrets_yml/version.rb
+++ b/lib/capistrano/secrets_yml/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module SecretsYml
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/capistrano/tasks/secrets_yml.rake
+++ b/lib/capistrano/tasks/secrets_yml.rake
@@ -29,6 +29,7 @@ namespace :secrets_yml do
 
   desc "secrets.yml file checks"
   task :check do
+    raise(":deploy_to in your app/config/deploy/\#{environment}.rb file cannot contain ~") if shared_path.to_s.include?('~') # SCP doesn't support ~ in the path
     invoke "secrets_yml:check_secrets_file_exists"
     invoke "secrets_yml:check_git_tracking"
     invoke "secrets_yml:check_config_present"
@@ -39,7 +40,8 @@ namespace :secrets_yml do
     content = secrets_yml_content
     on release_roles :all do
       execute :mkdir, "-pv", File.dirname(secrets_yml_remote_path)
-      upload! StringIO.new(content), secrets_yml_remote_path
+      Net::SCP.upload!(self.host.hostname, fetch(:system_user), StringIO.new(content), secrets_yml_remote_path)
+      # upload! StringIO.new(content), secrets_yml_remote_path
     end
   end
 


### PR DESCRIPTION
1. Switched upload! to Net::SCP.upload! so we can use new :system_user to specify the deployment ssh user we want. Added readme requirement.
2. gitignore changes
3. Added raise if :deploy_to path has ~ (SCP doesn't like it)
4. Version bump