### PR TITLE
Adding port setting to net scp uploader

### DIFF
--- a/lib/capistrano/tasks/secrets_yml.rake
+++ b/lib/capistrano/tasks/secrets_yml.rake
@@ -40,7 +40,7 @@ namespace :secrets_yml do
     content = secrets_yml_content
     on release_roles :all do
       execute :mkdir, "-pv", File.dirname(secrets_yml_remote_path)
-      Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(content), secrets_yml_remote_path)
+      Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(content), secrets_yml_remote_path, ssh: { port: self.host.port })
     end
   end
 


### PR DESCRIPTION
I was running `bundle exec cap stage_name setup` and found that the library could not perform any actions because of my not standard SSH port setup.

`SSHKit::Runner::ExecuteError: Exception while executing as xxxx@123.123.123.123: Connection refused - connect(2) for 123.123.123.123:22`

This PR fixes the issue.

Remember to setup your super cool port number in the server configuration:
```ruby
server '123.123.123.123', user: 'xxxx', roles: %w{web app db}, port: 123, my_property: :my_value
```
I tested my patch without any port specified and worked just fine. It tried the default 22 port number.
```ruby
server '123.123.123.123', user: 'xxxx', roles: %w{web app db}, my_property: :my_value
```

**Side note**

This config works with SSHKit, however does not with `Net::SCP`
```ruby
set :ssh_options, {
  forward_agent: true,
  port: 123
}
```


