### PR TITLE
`exists?` method no longer exists for `File:Class`

### DIFF
--- a/lib/capistrano/tasks/secrets_yml.rake
+++ b/lib/capistrano/tasks/secrets_yml.rake
@@ -10,7 +10,7 @@ end
 namespace :secrets_yml do
 
   task :check_secrets_file_exists do
-    next if File.exists?(secrets_yml_local_path)
+    next if File.exist?(secrets_yml_local_path)
     check_secrets_file_exists_error
     exit 1
   end


### PR DESCRIPTION
The `exists?` alias to method `exist?` was deprecated in Ruby 2.1, [and removed entirely in Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/). Instances of `exists?` calls should be replaced with the `exist?` method.