### PR TITLE
Explicitly require 'net/scp' 

### DIFF
--- a/capistrano-secrets-yml.gemspec
+++ b/capistrano-secrets-yml.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'capistrano', '>= 3.10'
   gem.add_dependency 'sshkit', '>= 1.17.0'
+  gem.add_dependency 'net-scp', '>= 4.0.0'
   gem.add_development_dependency 'rake', '~> 12.3'
 end

--- a/lib/capistrano/tasks/secrets_yml.rake
+++ b/lib/capistrano/tasks/secrets_yml.rake
@@ -1,3 +1,5 @@
+require 'net/scp'
+
 include Capistrano::SecretsYml::Paths
 include Capistrano::SecretsYml::Helpers
 namespace :load do task :defaults do


### PR DESCRIPTION
Not explicitly requiring 'net/scp' in ruby 3.3 / rails 7.1 makes the `bundle exec cap production setup` fail with `NameError: uninitialized constant Net::SCP (NameError)`

These commits fix that error.